### PR TITLE
Example of using a `.zenodo.json` file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,34 @@
+{
+    "title": "Addressing Uncertainty in MultiSector Dynamics Research",
+    "creators": [
+        {
+            "name": "Pat Reed",
+            "affiliation": "School of Civil and Environmental Engineering, Cornell University, Ithaca, NY, USA",
+            "orcid": "0000-0002-7963-6102"
+        },
+        {
+            "name": "Antonia Hadjimichael",
+            "affiliation": "School of Civil and Environmental Engineering, Cornell University, Ithaca, NY, USA",
+            "orcid": "0000-0001-7330-6834"
+        },
+        {
+            "name": "Chris Vernon",
+            "affiliation": "Pacific Northwest National Laboratory, Richland, WA., USA",
+            "orcid": "0000-0002-3406-6214"
+        }
+    ],
+    "contributors": [
+        {
+            "name": "Antonia Hadjimichael",
+            "affiliation": "School of Civil and Environmental Engineering, Cornell University, Ithaca, NY, USA",
+            "orcid": "0000-0001-7330-6834",
+            "type": "Editor"
+        },
+        {
+            "name": "Chris Vernon",
+            "affiliation": "Pacific Northwest National Laboratory, Richland, WA., USA",
+            "orcid": "0000-0002-3406-6214",
+            "type": "DataManager"
+        }
+    ]
+}


### PR DESCRIPTION
Example of using a `.zenodo.json` file to override the default zenodo DOI citation.

There are many fields you can override, but I haven't found a great documentation. Best I can find is to look [here](https://developers.zenodo.org/#representation) at the `Deposit metadata` section to see available fields.

In this example, I've shown both a "creators" and a "contributors" entry -- I'm not totally sure how those translate to the citation, but this should get us started.