### PR TITLE
Zenodo citation fix

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,3 @@
+{
+    "upload_type": "book"
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,4 @@
 cff-version: 1.2.0
-message: "Please cite our work as follows:"
 authors:
 - family-names: "Reed"
   given-names: "Patrick M."

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Addressing Uncertainty in MultiSector Dynamics Research
 
-[Read the living document here](https://immm-sfa.github.io/msd_uncertainty_ebook/)!
+### [Read the living document here](https://immm-sfa.github.io/msd_uncertainty_ebook/)!
 
 To provide feedback or report a bug, please [open an issue](https://github.com/IMMM-SFA/msd_uncertainty_ebook/issues/new).
 


### PR DESCRIPTION
Attempt to change the publication type from `Computer software` to `book` in Zenodo citation via the inclusion of a `.zenodo.json` file.  Hopes that there will not be conflicts with the `CITATION.cff` file.

Also, removed additional message from citation file.

Made link to ebook in README more prominent.

