### PR TITLE
Migrate notebooks to AWS

### DIFF
--- a/.github/workflows/02_deploy.yml
+++ b/.github/workflows/02_deploy.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Get current datetime in ISO format
         id: date
         run: echo "::set-output name=date::$(date -u +'%Y-%m-%d')"
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete
+        env:
+          SOURCE_DIR: 'notebooks'
+          DEST_DIR: 'notebooks'
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
       - name: Create GitHub release
         id: gh_release
         uses: softprops/action-gh-release@v1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,10 +24,10 @@ today = f"Last updated: {datetime.utcnow().strftime('%b %d, %Y')}"
 # -- Notebook URLs -----------------------------------------------------------
 
 rst_prolog = """
-.. _nb_logistic_regression: https://mybinder.org/v2/gh/IMMM-SFA/msd_uncertainty_ebook/main?labpath=notebooks%2Fbasin_users_logistic_regression.ipynb
-.. _nb_saltelli_sobol: https://mybinder.org/v2/gh/IMMM-SFA/msd_uncertainty_ebook/main?labpath=notebooks%2Fsa_saltelli_sobol_ishigami.ipynb
-.. _nb_hymod: https://mybinder.org/v2/gh/IMMM-SFA/msd_uncertainty_ebook/main?labpath=notebooks%2Fhymod.ipynb
-.. _nb_fishery_dynamics: https://mybinder.org/v2/gh/IMMM-SFA/msd_uncertainty_ebook/main?labpath=notebooks%2Ffishery_dynamics.ipynb
+.. _nb_logistic_regression: https://uc-ebook.msdlive.org/user-redirect/lab/tree/examples/basin_users_logistic_regression.ipynb
+.. _nb_saltelli_sobol: https://uc-ebook.msdlive.org/user-redirect/lab/tree/examples/sa_saltelli_sobol_ishigami.ipynb
+.. _nb_hymod: https://uc-ebook.msdlive.org/user-redirect/lab/tree/examples/hymod.ipynb
+.. _nb_fishery_dynamics: https://uc-ebook.msdlive.org/user-redirect/lab/tree/examples/fishery_dynamics.ipynb
 """
 
 

--- a/notebooks/basin_users_logistic_regression.ipynb
+++ b/notebooks/basin_users_logistic_regression.ipynb
@@ -31,6 +31,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### **NOTE:**  If you are running this notebook locally, run the following command to install the required package data:\n",
+    "\n",
+    "```python\n",
+    "msdbook.install_package_data()\n",
+    "```\n",
+    "\n",
+    "##### Otherwise, proceed with the following"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -50,9 +63,6 @@
     "import pandas as pd\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# load example data from Hadjimichael et al. (2020)\n",
-    "msdbook.install_package_data()\n",
     "\n",
     "# Select the IDs for the three users that we will perform the analysis for\n",
     "all_IDs = ['7000550','7200799','3704614'] \n",

--- a/notebooks/fishery_dynamics.ipynb
+++ b/notebooks/fishery_dynamics.ipynb
@@ -63,6 +63,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### **NOTE:**  If you are running this notebook locally, run the following command to install the required package data:\n",
+    "\n",
+    "```python\n",
+    "msdbook.install_package_data()\n",
+    "```\n",
+    "\n",
+    "##### Otherwise, proceed with the following"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -80,9 +93,6 @@
     "from SALib.sample import saltelli\n",
     "from SALib.analyze import sobol\n",
     "from matplotlib import patheffects as pe\n",
-    "\n",
-    "# load example data\n",
-    "msdbook.install_package_data()\n",
     "\n",
     "%matplotlib inline\n",
     "%config InlineBackend.print_figure_kwargs = {'bbox_inches':None}\n"

--- a/notebooks/hymod.ipynb
+++ b/notebooks/hymod.ipynb
@@ -105,6 +105,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### **NOTE:**  If you are running this notebook locally, run the following command to install the required package data:\n",
+    "\n",
+    "```python\n",
+    "msdbook.install_package_data()\n",
+    "```\n",
+    "\n",
+    "##### Otherwise, proceed with the following"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -119,9 +132,6 @@
     "\n",
     "from sklearn import metrics\n",
     "from matplotlib import pyplot as plt\n",
-    "\n",
-    "# load example data\n",
-    "msdbook.install_package_data()\n",
     "\n",
     "# load the Leaf River HYMOD input file\n",
     "leaf_data = msdbook.load_hymod_input_file()\n",


### PR DESCRIPTION
**Purpose:**
Migrate notebooks from Binder to AWS to be hosted via MSD-LIVE

**Notes:**

- changed targets to notebooks in `docs/source/conf.py` to reflect where they are hosted on AWS
- removed the command to download the supplemental data from Zenodo in the notebooks and set it up as a note instead for users who wish to run them locally
- added GitHub action to auto-deploy notebooks to an S3 bucket on push to main