### PR TITLE
set up a development employment environment

### DIFF
--- a/.github/workflows/01_test.yml
+++ b/.github/workflows/01_test.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, feature/dev-site ]
+    branches: [ main, dev ]
 
 jobs:
   build:

--- a/.github/workflows/01_test.yml
+++ b/.github/workflows/01_test.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/dev-site ]
 
 jobs:
   build:

--- a/.github/workflows/03_dev_deploy.yml
+++ b/.github/workflows/03_dev_deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [ feature/dev-site ]
 
 jobs:
   build:
@@ -21,6 +21,8 @@ jobs:
           pip install -r requirements.txt
       - name: Build html and pdf ebook
         working-directory: 'docs/'
+        env:
+          NODE_ENV: development
         run: |
           make html latexpdf --keep-going LATEXMKOPTS="-interaction=nonstopmode" || true
           make latexpdf --keep-going LATEXMKOPTS="-interaction=nonstopmode" || true
@@ -35,19 +37,16 @@ jobs:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: landing/package-lock.json
-      - name: Get current datetime in ISO format
-        id: date
-        run: echo "::set-output name=date::$(date -u +'%Y-%m-%d')"
       - uses: jakejarvis/s3-sync-action@master
         with:
           args: --delete
         env:
           SOURCE_DIR: 'notebooks'
           DEST_DIR: 'notebooks'
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_DEV }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+          AWS_REGION: ${{ secrets.AWS_REGION_DEV }}
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -57,29 +56,27 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: Dockerfile_dev
           push: true
-          tags: thurber/uc-ebook.org:latest
-      - name: Create GitHub release
-        id: gh_release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: docs/build/latex/addressinguncertaintyinmultisectordynamicsresearch.pdf
-          tag_name: ${{ steps.date.outputs.date }}v${{ github.run_number }}
+          tags: thurber/uc-ebook.org:dev
       - name: Install landing page dependencies
         working-directory: 'landing/'
         run: npm install
       - name: Build landing page
         working-directory: 'landing/'
         env:
-          NODE_ENV: production
-          VITE_PDF_URL: https://github.com/IMMM-SFA/msd_uncertainty_ebook/releases/download/${{ steps.date.outputs.date }}v${{ github.run_number }}/addressinguncertaintyinmultisectordynamicsresearch.pdf
+          NODE_ENV: development
+          VITE_PDF_URL: https://uc-ebook.org/dev/images/addressinguncertaintyinmultisectordynamicsresearch.pdf
         run: npm run build
       - name: Commit documentation changes
         run: |
-          git clone --depth=1 --branch=gh-pages https://github.com/IMMM-SFA/msd_uncertainty_ebook.git previous_deploy
-          mkdir ./landing/build/dev
-          cp -r ./previous_deploy/dev/* ./landing/build/dev/
-          cd ./landing/build
+          git clone --depth=1 --branch=gh-pages https://github.com/IMMM-SFA/msd_uncertainty_ebook.git deploy
+          rm -rf ./deploy/.git
+          rm -rf ./deploy/dev
+          mkdir ./deploy/dev
+          cp -r ./landing/build/* ./deploy/dev/
+          cp ./docs/build/latex/addressinguncertaintyinmultisectordynamicsresearch.pdf ./deploy/dev/images/
+          cd ./deploy
           git init
           git add -A
           git config --local user.email "action@github.com"
@@ -88,7 +85,7 @@ jobs:
       - name: Push changes to gh-pages
         uses: ad-m/github-push-action@master
         with:
-          branch: gh-pages
-          directory: landing/build
+          branch: gh-pages-test
+          directory: deploy
           force: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/03_dev_deploy.yml
+++ b/.github/workflows/03_dev_deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy
+name: Deploy Dev
 
 on:
   push:
-    branches: [ feature/dev-site ]
+    branches: [ dev ]
 
 jobs:
   build:
@@ -66,7 +66,6 @@ jobs:
         working-directory: 'landing/'
         env:
           NODE_ENV: development
-          VITE_PDF_URL: https://uc-ebook.org/dev/images/addressinguncertaintyinmultisectordynamicsresearch.pdf
         run: npm run build
       - name: Commit documentation changes
         run: |
@@ -75,7 +74,6 @@ jobs:
           rm -rf ./deploy/dev
           mkdir ./deploy/dev
           cp -r ./landing/build/* ./deploy/dev/
-          cp ./docs/build/latex/addressinguncertaintyinmultisectordynamicsresearch.pdf ./deploy/dev/images/
           cd ./deploy
           git init
           git add -A
@@ -85,7 +83,7 @@ jobs:
       - name: Push changes to gh-pages
         uses: ad-m/github-push-action@master
         with:
-          branch: gh-pages-test
+          branch: gh-pages
           directory: deploy
           force: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,0 +1,13 @@
+FROM jupyter/minimal-notebook:2022-05-03
+
+USER root
+
+RUN git clone --depth=1 --branch=feature/dev-site https://github.com/IMMM-SFA/msd_uncertainty_ebook.git msd_uncertainty_ebook
+RUN cd msd_uncertainty_ebook && pip install .
+
+# Now create a symlinked data folder inside the msdbook package that links to /home/demo/data folder
+RUN mkdir -p /home/demo/data
+RUN rm -rf /opt/conda/lib/python3.9/site-packages/msdbook/data
+RUN ln -s /home/demo/data /opt/conda/lib/python3.9/site-packages/msdbook/data
+
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,19 +17,23 @@ from datetime import datetime
 sys.path.insert(0, os.path.abspath('../../'))
 sys.path.append(os.path.abspath("../../extensions"))
 
+# if this is a dev build, the paths need to be adjusted
+dev_web = '/dev' if ('NODE_ENV' in os.environ and os.environ['NODE_ENV'] == 'development') else ''
+dev_nb = '.dev' if ('NODE_ENV' in os.environ and os.environ['NODE_ENV'] == 'development') else ''
+
 # current datetime to use as the version
 today = f"Last updated: {datetime.utcnow().strftime('%b %d, %Y')}"
 
 
 # -- Notebook URLs -----------------------------------------------------------
 
-rst_prolog = """
-.. _nb_logistic_regression: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/basin_users_logistic_regression.ipynb
-.. _nb_saltelli_sobol: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/sa_saltelli_sobol_ishigami.ipynb
-.. _nb_hymod: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/hymod.ipynb
-.. _nb_fishery_dynamics: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/fishery_dynamics.ipynb
-.. _nb_discovery: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/Bedford_Greene_SD_tutorial.ipynb
-.. _nb_hmm: https://uc-ebook.msdlive.org/user-redirect/lab/tree/notebooks/Hidden-Markov_Modeling_Approaches_to_Creating_Synthetic_Streamflow_Scenarios.ipynb
+rst_prolog = f"""
+.. _nb_logistic_regression: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/basin_users_logistic_regression.ipynb
+.. _nb_saltelli_sobol: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/sa_saltelli_sobol_ishigami.ipynb
+.. _nb_hymod: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/hymod.ipynb
+.. _nb_fishery_dynamics: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/fishery_dynamics.ipynb
+.. _nb_discovery: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/Bedford_Greene_SD_tutorial.ipynb
+.. _nb_hmm: https://uc-ebook{dev_nb}.msdlive.org/user-redirect/lab/tree/notebooks/Hidden-Markov_Modeling_Approaches_to_Creating_Synthetic_Streamflow_Scenarios.ipynb
 """
 
 
@@ -88,7 +92,7 @@ html_theme = 'sphinx_book_theme'
 
 # theme options
 html_theme_options = {
-    'path_to_docs': '/docs',
+    'path_to_docs': f'{dev_web}/docs',
     'repository_url': 'https://github.com/IMMM-SFA/msd_uncertainty_ebook',
     'use_issues_button': True,
     'use_download_button': True,

--- a/landing/svelte.config.js
+++ b/landing/svelte.config.js
@@ -13,7 +13,7 @@ const config = {
 			assets: 'build'
 		}),
 		paths: {
-			base: ''
+			base: process.env.NODE_ENV === 'development' ? '/dev' : ''
 		}
 	}
 };


### PR DESCRIPTION
This will work by deploying dev builds into a subfolder of the production deployment, such that deploying to either environment will preserve the state of the other environment. The root dev site will live at uc-ebook.org/dev